### PR TITLE
chore(iam): add new permissions for Prowler

### DIFF
--- a/cloudformation/prowler-pro-scan-role.yaml
+++ b/cloudformation/prowler-pro-scan-role.yaml
@@ -51,18 +51,23 @@ Resources:
                 - 'account:Get*'
                 - 'appstream:Describe*'
                 - 'appstream:List*'
+                - 'backup:List*'
+                - 'cloudtrail:GetInsightSelectors'
                 - 'codeartifact:List*'
                 - 'codebuild:BatchGet*'
+                - 'drs:Describe*'
                 - 'ds:Get*'
                 - 'ds:Describe*'
                 - 'ds:List*'
                 - 'ec2:GetEbsEncryptionByDefault'
                 - 'ecr:Describe*'
+                - 'ecr:GetRegistryScanningConfiguration'
                 - 'elasticfilesystem:DescribeBackupPolicy'
                 - 'glue:GetConnections'
                 - 'glue:GetSecurityConfiguration*'
                 - 'glue:SearchTables'
                 - 'lambda:GetFunction*'
+                - 'logs:FilterLogEvents'
                 - 'macie2:GetMacieSession'
                 - 's3:GetAccountPublicAccessBlock'
                 - 'shield:DescribeProtection'
@@ -70,6 +75,7 @@ Resources:
                 - 'securityhub:BatchImportFindings'
                 - 'securityhub:GetFindings'
                 - 'ssm:GetDocument'
+                - 'ssm-incidents:List*'
                 - 'support:Describe*'
                 - 'tag:GetTagKeys'
               Resource: '*'
@@ -80,7 +86,9 @@ Resources:
             - Effect: Allow
               Action:
                 - 'apigateway:GET'
-              Resource: 'arn:aws:apigateway:*::/restapis/*'
+              Resource: 
+                - 'arn:aws:apigateway:*::/restapis/*'
+                - 'arn:aws:apigateway:*::/apis/*'
       Tags:
         - Key: "Service"
           Value: "https://prowler.pro"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -57,18 +57,23 @@ data "aws_iam_policy_document" "prowler_pro_saas_role_policy" {
       "account:Get*",
       "appstream:Describe*",
       "appstream:List*",
+      "backup:List*",
+      "cloudtrail:GetInsightSelectors",
       "codeartifact:List*",
       "codebuild:BatchGet*",
+      "drs:Describe*",
       "ds:Get*",
       "ds:Describe*",
       "ds:List*",
       "ec2:GetEbsEncryptionByDefault",
       "ecr:Describe*",
+      "ecr:GetRegistryScanningConfiguration",
       "elasticfilesystem:DescribeBackupPolicy",
       "glue:GetConnections",
       "glue:GetSecurityConfiguration*",
       "glue:SearchTables",
       "lambda:GetFunction*",
+      "logs:FilterLogEvents",
       "macie2:GetMacieSession",
       "s3:GetAccountPublicAccessBlock",
       "shield:DescribeProtection",
@@ -76,6 +81,7 @@ data "aws_iam_policy_document" "prowler_pro_saas_role_policy" {
       "securityhub:BatchImportFindings",
       "securityhub:GetFindings",
       "ssm:GetDocument",
+      "ssm-incidents:List*",
       "support:Describe*",
       "tag:GetTagKeys"
     ]
@@ -89,7 +95,7 @@ data "aws_iam_policy_document" "prowler_pro_saas_role_apigw_policy" {
     actions = [
       "apigateway:GET"
     ]
-    resources = ["arn:aws:apigateway:*::/restapis/*"]
+    resources = ["arn:aws:apigateway:*::/restapis/*", "arn:aws:apigateway:*::/apis/*"]
   }
 }
 


### PR DESCRIPTION
Add IAM new permissions to the ProwlerPro SaaS Scan Role because of the new checks:

- cloudtrail:GetInsightSelectors
- backup:ListBackupPlans
- backup:ListReportPlans
- logs:FilterLogEvents
- drs:DescribeJobs
- ecr:GetRegistryScanningConfiguration
- ssm-incidents:ListReplicationSets
- ssm-incidents:ListResponsePlans
